### PR TITLE
Guard nerf extras against unsupported open3d interpreters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ To enable NeRF training with nerfstudio, install the optional extras:
 pip install -e .[nerf]
 ```
 
+> **Important:** The `nerf` extra pulls in `open3d`, which currently provides
+> prebuilt wheels only for Python 3.12 and earlier. Use Python 3.12 when
+> installing the extra (our setup scripts will warn you automatically) or skip
+> the extra on newer interpreters to avoid pip dependency conflicts.
+
 ### 4. Configure environment (optional)
 
 Copy `.env.example` to `.env` and adjust values if you want to override defaults such as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-nerf = ["nerfstudio>=0.3.4"]
+# The optional "nerf" extra intentionally pins both nerfstudio and open3d. Newer
+# nerfstudio releases require open3d>=0.16.0, but open3d only publishes wheels
+# up to Python 3.12 at the time of writing. The marker guards against pip trying
+# to resolve the dependency on unsupported interpreters where it would fail with
+# confusing conflicts.
+nerf = [
+    "nerfstudio>=1.1.5",
+    "open3d>=0.19.0; python_version < '3.13'",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/setup_environment.ps1
+++ b/scripts/setup_environment.ps1
@@ -85,6 +85,20 @@ try {
         if ($item) { $extrasClean += $item.Trim() }
     }
 
+    $extrasLower = @()
+    foreach ($item in $extrasClean) {
+        if ($item) { $extrasLower += $item.ToLowerInvariant() }
+    }
+
+    if ($extrasLower -contains 'nerf') {
+        $versionParts = $pythonVersion.Split('.')
+        $pyMajor = [int]$versionParts[0]
+        $pyMinor = if ($versionParts.Count -gt 1) { [int]$versionParts[1] } else { 0 }
+        if (($pyMajor -gt 3) -or ($pyMajor -eq 3 -and $pyMinor -ge 13)) {
+            throw "The 'nerf' extra requires Python 3.12 or lower because open3d currently publishes wheels up to that interpreter version. Re-run with -Python targeting Python 3.12 or omit the extra."
+        }
+    }
+
     $installTarget = '.'
     if ($extrasClean.Count -gt 0) {
         $extrasArgument = $extrasClean -join ','

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -113,6 +113,14 @@ log "INFO" "Upgrading pip inside the virtual environment"
 
 # Normalise extras to remove whitespace so pip receives a clean target string.
 extras_clean=${extras_raw// /}
+extras_lower=$(printf '%s' "$extras_clean" | tr '[:upper:]' '[:lower:]')
+if [[ ",$extras_lower," == *",nerf,"* ]]; then
+  py_major=$("$python_cmd" -c 'import sys; print(sys.version_info[0])')
+  py_minor=$("$python_cmd" -c 'import sys; print(sys.version_info[1])')
+  if (( py_major > 3 || (py_major == 3 && py_minor >= 13) )); then
+    fatal "The 'nerf' extra requires Python 3.12 or lower because open3d only publishes wheels up to that version. Re-run with --python pointing to Python 3.12 or omit the extra."
+  fi
+fi
 install_target="."
 if [[ -n "$extras_clean" ]]; then
   install_target=".[${extras_clean}]"


### PR DESCRIPTION
## Summary
- pin the nerf optional dependency to nerfstudio 1.1.5 and open3d 0.19 with a Python 3.12 compatibility marker
- teach the setup scripts to block installing the nerf extra when running on Python 3.13+ and surface clear guidance
- document the Python version requirement for the nerf extra in the main README so operators avoid pip resolver conflicts

## Testing
- .venv/bin/python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4225f93008328a1258d6dcb106ad5