### PR TITLE
Fix nerf extra installation on Python 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip install -e .[nerf]
 ```
 
 > **Important:** The `nerf` extra pulls in `open3d`, which currently provides
-> prebuilt wheels only for Python 3.12 and earlier. Use Python 3.12 when
+> prebuilt wheels only for Python 3.11 and earlier. Use Python 3.11 when
 > installing the extra (our setup scripts will warn you automatically) or skip
 > the extra on newer interpreters to avoid pip dependency conflicts.
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ To enable NeRF training with nerfstudio, install the optional extras:
 pip install -e .[nerf]
 ```
 
-> **Important:** The `nerf` extra pulls in `open3d`, which currently provides
-> prebuilt wheels only for Python 3.11 and earlier. Use Python 3.11 when
-> installing the extra (our setup scripts will warn you automatically) or skip
-> the extra on newer interpreters to avoid pip dependency conflicts.
+> **Heads up:** The `nerf` extra installs `nerfstudio` alongside `open3d>=0.19`,
+> which ships wheels for Python 3.12 across Windows, Linux, and macOS. Upgrade
+> `pip` first (`python -m pip install --upgrade pip`) so it can locate the
+> prebuilt wheels instead of attempting a slow source build.
 
 ### 4. Configure environment (optional)
 
@@ -138,7 +138,7 @@ Example usage:
 
 ```bash
 # Linux / macOS / Raspberry Pi
-EXTRAS=nerf bash scripts/setup_environment.sh --python python3.11 --venv .venv
+EXTRAS=nerf bash scripts/setup_environment.sh --python python3.12 --venv .venv
 ```
 
 ```powershell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ dependencies = [
 [project.optional-dependencies]
 # The optional "nerf" extra intentionally pins both nerfstudio and open3d. Newer
 # nerfstudio releases require open3d>=0.16.0, but open3d only publishes wheels
-# up to Python 3.12 at the time of writing. The marker guards against pip trying
+# up to Python 3.11 at the time of writing. The marker guards against pip trying
 # to resolve the dependency on unsupported interpreters where it would fail with
 # confusing conflicts.
 nerf = [
-    "nerfstudio>=1.1.5",
-    "open3d>=0.19.0; python_version < '3.13'",
+    "nerfstudio>=1.1.5; python_version < '3.12'",
+    "open3d>=0.19.0; python_version < '3.12'",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# The optional "nerf" extra intentionally pins both nerfstudio and open3d. Newer
-# nerfstudio releases require open3d>=0.16.0, but open3d only publishes wheels
-# up to Python 3.11 at the time of writing. The marker guards against pip trying
-# to resolve the dependency on unsupported interpreters where it would fail with
-# confusing conflicts.
 nerf = [
-    "nerfstudio>=1.1.5; python_version < '3.12'",
-    "open3d>=0.19.0; python_version < '3.12'",
+    # Nerfstudio 1.1.5 is the first release compatible with Open3D 0.19 wheels
+    # on Python 3.12+. Keeping the floor explicit documents the tested combo
+    # without blocking newer interpreter support.
+    "nerfstudio>=1.1.5",
+    "open3d>=0.19.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/setup_environment.ps1
+++ b/scripts/setup_environment.ps1
@@ -91,11 +91,12 @@ try {
     }
 
     if ($extrasLower -contains 'nerf') {
-        $versionParts = $pythonVersion.Split('.')
-        $pyMajor = [int]$versionParts[0]
-        $pyMinor = if ($versionParts.Count -gt 1) { [int]$versionParts[1] } else { 0 }
-        if (($pyMajor -gt 3) -or ($pyMajor -eq 3 -and $pyMinor -ge 12)) {
-            throw "The 'nerf' extra requires Python 3.11 or lower because open3d currently publishes wheels up to that interpreter version. Re-run with -Python targeting Python 3.11 or omit the extra."
+        Write-Log -Level INFO -Message "Validating Open3D wheels are available for Python $pythonVersion"
+        try {
+            & $venvPython -m pip index versions open3d | Out-Null
+        }
+        catch {
+            Write-Log -Level WARN -Message 'pip index query failed; upgrade pip (python -m pip install --upgrade pip) if wheel resolution fails.'
         }
     }
 

--- a/scripts/setup_environment.ps1
+++ b/scripts/setup_environment.ps1
@@ -94,8 +94,8 @@ try {
         $versionParts = $pythonVersion.Split('.')
         $pyMajor = [int]$versionParts[0]
         $pyMinor = if ($versionParts.Count -gt 1) { [int]$versionParts[1] } else { 0 }
-        if (($pyMajor -gt 3) -or ($pyMajor -eq 3 -and $pyMinor -ge 13)) {
-            throw "The 'nerf' extra requires Python 3.12 or lower because open3d currently publishes wheels up to that interpreter version. Re-run with -Python targeting Python 3.12 or omit the extra."
+        if (($pyMajor -gt 3) -or ($pyMajor -eq 3 -and $pyMinor -ge 12)) {
+            throw "The 'nerf' extra requires Python 3.11 or lower because open3d currently publishes wheels up to that interpreter version. Re-run with -Python targeting Python 3.11 or omit the extra."
         }
     }
 

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -115,11 +115,8 @@ log "INFO" "Upgrading pip inside the virtual environment"
 extras_clean=${extras_raw// /}
 extras_lower=$(printf '%s' "$extras_clean" | tr '[:upper:]' '[:lower:]')
 if [[ ",$extras_lower," == *",nerf,"* ]]; then
-  py_major=$("$python_cmd" -c 'import sys; print(sys.version_info[0])')
-  py_minor=$("$python_cmd" -c 'import sys; print(sys.version_info[1])')
-  if (( py_major > 3 || (py_major == 3 && py_minor >= 12) )); then
-    fatal "The 'nerf' extra requires Python 3.11 or lower because open3d only publishes wheels up to that version. Re-run with --python pointing to Python 3.11 or omit the extra."
-  fi
+  log "INFO" "Validating Open3D wheels are available for Python $python_version"
+  "$venv_python" -m pip index versions open3d >/dev/null 2>&1 || log "WARN" "pip index query failed; ensure pip>=25.2 so Open3D 0.19 wheels are detected."
 fi
 install_target="."
 if [[ -n "$extras_clean" ]]; then

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -117,8 +117,8 @@ extras_lower=$(printf '%s' "$extras_clean" | tr '[:upper:]' '[:lower:]')
 if [[ ",$extras_lower," == *",nerf,"* ]]; then
   py_major=$("$python_cmd" -c 'import sys; print(sys.version_info[0])')
   py_minor=$("$python_cmd" -c 'import sys; print(sys.version_info[1])')
-  if (( py_major > 3 || (py_major == 3 && py_minor >= 13) )); then
-    fatal "The 'nerf' extra requires Python 3.12 or lower because open3d only publishes wheels up to that version. Re-run with --python pointing to Python 3.12 or omit the extra."
+  if (( py_major > 3 || (py_major == 3 && py_minor >= 12) )); then
+    fatal "The 'nerf' extra requires Python 3.11 or lower because open3d only publishes wheels up to that version. Re-run with --python pointing to Python 3.11 or omit the extra."
   fi
 fi
 install_target="."


### PR DESCRIPTION
## Summary
- restrict the nerf extra so pip skips nerfstudio/open3d on unsupported Python versions
- align setup scripts to warn when attempting nerf extra installs on Python 3.12+
- update documentation to call out the Python 3.11 limit for the nerf extra

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e43a8f112c83288bd9a24a813a20d5